### PR TITLE
support Quail version of Android Studio

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Search for **"Build finish notifier"** in Android studio plugins.
 </p>
 
 ## Supported Android studio version
+- Quail(2025.4.x)
 - Panda(2025.3.x)
 - Otter(2025.2.x)
 - Narwhal(2025.1.x)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "com.isaac"
-version = "1.0.10"
+version = "1.0.11"
 
 repositories {
     mavenCentral()
@@ -28,8 +28,8 @@ tasks {
 
     patchPluginXml {
         sinceBuild.set("213")
-        untilBuild.set("253.*")
-        changeNotes.set("Fixed issues with compatibility in the Panda version of Android Studio.")
+        untilBuild.set("254.*")
+        changeNotes.set("Fixed issues with compatibility in the Quail version of Android Studio.")
     }
 
     signPlugin {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,8 +28,8 @@ tasks {
 
     patchPluginXml {
         sinceBuild.set("213")
-        untilBuild.set("254.*")
-        changeNotes.set("Fixed issues with compatibility in the Quail version of Android Studio.")
+        untilBuild.set("263.*")
+        changeNotes.set("Extended compatibility to cover Android Studio builds up to 263.*.")
     }
 
     signPlugin {


### PR DESCRIPTION
## Summary

- Bumps plugin version from `1.0.10` to `1.0.11`
- Updates `untilBuild` from `253.*` to `263.*` to support Android Studio Quail (2025.4.x) and future builds up to 263
- Adds Quail (2025.4.x) to the supported versions list in README

## Test plan

- [ ] `./gradlew buildPlugin` completes without errors
- [ ] Generated artifact in `build/distributions/` is versioned `1.0.11`
- [ ] `build/patchedPluginXmlFiles/plugin.xml` shows `until-build="263.*"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)